### PR TITLE
Use sf::Shader::Bind() correctly after latest update of the SFML's API.

### DIFF
--- a/src/System/window.cpp
+++ b/src/System/window.cpp
@@ -307,13 +307,11 @@ namespace window {
         window_.setActive(true);
         glEnable(GL_TEXTURE_2D);
 
-        if (shader)
-            shader->bind();
+        sf::Shader::bind(shader);
 
         window_.draw(toBeDrawn, states);
 
-        if (shader)
-            shader->unbind();
+        sf::Shader::bind(NULL);
 
         window_.popGLStates();
         glPopMatrix();


### PR DESCRIPTION
Hi,

In latests revisions of SFML, to bind a shader, one now needs to call the static method sf::Shader::bind() giving it a pointer to the desired shader as a parameter, and unbinding is done by passing NULL to this method. It's also not necessary to check for the shader to be non-NULL before calling the method anymore, except if you want to avoid unnecessary GL calls at all when shader is NULL.

Attached patch allows to use the latest version of SFML and removes the non-NULL tests before calling sf::Shader::bind().

Bye,
## 

Sylvain
