### PR TITLE
Don’t try to read a path that wasn’t supplied in the command line options.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,10 +61,16 @@ int main(int argc, char* argv[]) {
             return 0;
         }
         else if (std::string(argv[i]) == "-cfg") {
-            settings::C_configPath = argv[++i];
+            if (++i < argc)
+                settings::C_configPath = argv[i];
+            else
+                std::cout << "Option \"-cfg\" expects a path to be provided following it.\n";
         }
         else if (std::string(argv[i]) == "-data") {
-            settings::C_dataPath = argv[++i];
+            if (++i < argc)
+                settings::C_dataPath = argv[i];
+            else
+                std::cout << "Option \"-data\" expects a path to be provided following it.\n";
         }
         else {
             std::cout << "Unknown option \"" << argv[i] << "\". Use -help for a complete list of supported flags.\n";


### PR DESCRIPTION
Hi,

When the options "-cfg" or "-data" are provided at the end of the command line without a path, M.A.R.S. segfaults and dies.

Attached patch fixes the problem by preventing an off-by-one access to argv[] and display a non-fatal error message in these cases.

Best wishes,
## 

Sylvain Boilard
