### PR TITLE
Fix OpenAL AL_INVALID_VALUE warning when starting a game.

### DIFF
--- a/src/Media/music.cpp
+++ b/src/Media/music.cpp
@@ -70,6 +70,8 @@ namespace music {
 
             if (fadeOutTimer_ > 0.f) {
                 fadeOutTimer_ -= timer::realFrameTime();
+                if (fadeOutTimer_ < 0.f)
+                    fadeOutTimer_ = 0.f;
                 musicChannel_.setVolume(settings::C_musicVolume*fadeOutTimer_*2.5f);
             }
 


### PR DESCRIPTION
The warning is produced because setVolume is called with a negative value, so ensure it never is.
