### PR TITLE
Remove dependency on GLU - fixes build with SFML 2.3

### DIFF
--- a/premake4.lua
+++ b/premake4.lua
@@ -11,11 +11,11 @@ project "mars"
     defines { "NDEBUG" }
     flags   { "Optimize" }
     if os.get() == "windows" then
-      links { "sfml-graphics", "sfml-audio", "sfml-system", "sfml-window", "glu32", "opengl32", "fribidi-0", "tag" }
+      links { "sfml-graphics", "sfml-audio", "sfml-system", "sfml-window", "opengl32", "fribidi-0", "tag" }
     elseif os.get() == "macosx" then
       links { "sfml-graphics.framework", "sfml-audio.framework", "sfml-system.framework", "sfml-window.framework", "opengl.framework", "fribidi", "tag" }
     else
-      links { "GLU", "sfml-graphics", "sfml-audio", "sfml-system", "sfml-window", "fribidi", "tag" }
+      links { "sfml-graphics", "sfml-audio", "sfml-system", "sfml-window", "fribidi", "tag" }
       libdirs { "/usr/lib", "/usr/local/lib" }
     end
     
@@ -23,10 +23,10 @@ project "mars"
     defines { "_DEBUG", "DEBUG" }
     flags   { "Symbols" }
     if os.get() == "windows" then
-      links { "sfml-graphics", "sfml-audio", "sfml-system", "sfml-window", "glu32", "opengl32", "fribidi-0", "tag" }
+      links { "sfml-graphics", "sfml-audio", "sfml-system", "sfml-window", "opengl32", "fribidi-0", "tag" }
     elseif os.get() == "macosx" then
       links { "sfml-graphics.framework", "sfml-audio.framework", "sfml-system.framework", "sfml-window.framework", "opengl.framework", "fribidi", "tag" }
     else
-      links { "GLU", "sfml-graphics", "sfml-audio", "sfml-system", "sfml-window", "fribidi", "tag" }
+      links { "sfml-graphics", "sfml-audio", "sfml-system", "sfml-window", "fribidi", "tag" }
       libdirs { "/usr/lib", "/usr/local/lib" }
     end

--- a/src/Shaders/postFX.cpp
+++ b/src/Shaders/postFX.cpp
@@ -78,7 +78,7 @@ namespace postFX {
             postFX_.loadFromFile(settings::C_dataPath + "shaders/bump.frag", sf::Shader::Fragment);
             bumpMap_.create(SPACE_X_RESOLUTION*0.5f, SPACE_Y_RESOLUTION*0.5f);
             glViewport(0,0,SPACE_X_RESOLUTION*0.5f,SPACE_Y_RESOLUTION*0.5f);
-            gluOrtho2D(0, SPACE_X_RESOLUTION, SPACE_Y_RESOLUTION, 0);
+            glOrtho(0, SPACE_X_RESOLUTION, SPACE_Y_RESOLUTION, 0, -1, 1);
             glEnable(GL_BLEND);
             glMatrixMode(GL_MODELVIEW);
             postFX_.setParameter("BumpMap", bumpMap_.getTexture());

--- a/src/System/window.cpp
+++ b/src/System/window.cpp
@@ -222,7 +222,7 @@ namespace window {
         glLoadIdentity();
 
         // Setup translation (according to left-upper corner)
-        gluOrtho2D(0.f, SPACE_X_RESOLUTION, SPACE_Y_RESOLUTION, 0.f);
+        glOrtho(0.f, SPACE_X_RESOLUTION, SPACE_Y_RESOLUTION, 0.f, -1, 1);
 
         // probably improves performance...
         glDisable(GL_LIGHTING);
@@ -247,7 +247,7 @@ namespace window {
 
         glMatrixMode(GL_PROJECTION);
         glLoadIdentity();
-        gluOrtho2D(0.f, viewPort_.x_, viewPort_.y_, 0.f);
+        glOrtho(0.f, viewPort_.x_, viewPort_.y_, 0.f, -1, 1);
         glMatrixMode(GL_MODELVIEW);
         glLoadIdentity();
 
@@ -255,7 +255,7 @@ namespace window {
 
         glMatrixMode(GL_PROJECTION);
         glLoadIdentity();
-        gluOrtho2D(0.f, SPACE_X_RESOLUTION, SPACE_Y_RESOLUTION, 0.f);
+        glOrtho(0.f, SPACE_X_RESOLUTION, SPACE_Y_RESOLUTION, 0.f, -1, 1);
         glMatrixMode(GL_MODELVIEW);
         glLoadIdentity();
     }
@@ -270,7 +270,7 @@ namespace window {
             glLoadIdentity();
             setViewPort();
 
-            gluOrtho2D(0.f, viewPort_.x_, viewPort_.y_, 0.f);
+            glOrtho(0.f, viewPort_.x_, viewPort_.y_, 0.f, -1, 1);
 
             glMatrixMode(GL_MODELVIEW);
             glLoadIdentity();
@@ -284,7 +284,7 @@ namespace window {
             glLoadIdentity();
             setViewPort();
 
-            gluOrtho2D(0.f, viewPort_.x_, viewPort_.y_, 0.f);
+            glOrtho(0.f, viewPort_.x_, viewPort_.y_, 0.f, -1, 1);
 
             glMatrixMode(GL_MODELVIEW);
             glLoadIdentity();
@@ -294,7 +294,7 @@ namespace window {
         else {
             glMatrixMode(GL_PROJECTION);
             glLoadIdentity();
-            gluOrtho2D(0.f, viewPort_.x_, viewPort_.y_, 0.f);
+            glOrtho(0.f, viewPort_.x_, viewPort_.y_, 0.f, -1, 1);
             glMatrixMode(GL_MODELVIEW);
             glLoadIdentity();
         }


### PR DESCRIPTION
The `SFML/OpenGL.h` header in SFML 2.3 no longer includes `glu.h` and since MARS doesn't include it directly, this beaks the build. There are only very few uses of GLU so I think the best way to fix this is to drop the dependency and convert the uses to standard OpenGL functions. I've done that in this pull request.

Please merge #2 before this one.
