### PR TITLE
Performance Upgrade by Storing values_.size()

### DIFF
--- a/src/Interface/ComboBox.cpp
+++ b/src/Interface/ComboBox.cpp
@@ -60,15 +60,16 @@ void ComboBox::mouseMoved(Vector2f const& position) {
 }
 
 void ComboBox::mouseWheelMoved(Vector2f const& position, int delta) {
-    if (hovered_ && values_.size() > 1) {
+    int valsize(values_.size());
+    if (hovered_ && valsize > 1) {
         int i(0);
-        for (i=0; i<values_.size(); ++i) {
+        for (i=0; i<valsize; ++i) {
             if (values_[i] == (*currentValue_))
                 break;
         }
         i-=delta;
         if      (i<0)               i=0;
-        else if (i>=values_.size()) i=values_.size()-1;
+        else if (i>=valsize) i=valsize-1;
         (*currentValue_) = values_[i];
     }
 }

--- a/src/Interface/ComboBox.cpp
+++ b/src/Interface/ComboBox.cpp
@@ -60,16 +60,16 @@ void ComboBox::mouseMoved(Vector2f const& position) {
 }
 
 void ComboBox::mouseWheelMoved(Vector2f const& position, int delta) {
-    int valsize(values_.size());
-    if (hovered_ && valsize > 1) {
+    int values_size(values_.size());
+    if (hovered_ && values_size > 1) {
         int i(0);
-        for (i=0; i<valsize; ++i) {
+        for (i=0; i<values_size; ++i) {
             if (values_[i] == (*currentValue_))
                 break;
         }
         i-=delta;
         if      (i<0)               i=0;
-        else if (i>=valsize) i=valsize-1;
+        else if (i>=values_size) i=values_size-1;
         (*currentValue_) = values_[i];
     }
 }


### PR DESCRIPTION
In ComboBox::mouseWheelMoved, values_.size() was called four times. If I recall, the size() function counts the number of elements in the callee's container. So this code was counting **n** values **4** times. By storing it in a variable _valsize_, size only gets calculated once.
