### PR TITLE
Removed Indentation by Returning Early

### DIFF
--- a/src/Items/PUReverse.cpp
+++ b/src/Items/PUReverse.cpp
@@ -24,30 +24,30 @@ this program.  If not, see <http://www.gnu.org/licenses/>. */
 void PUReverse::draw() const {
     if (!collected_) {
         PowerUp::draw();
+        return;
     }
-    else {
-        glBlendFunc(GL_SRC_ALPHA, GL_ONE);
-        for (std::list<Ship*>::const_iterator it = ships_.begin(); it != ships_.end(); ++it) {
 
-            glPushMatrix();
-            glLoadIdentity();
-            glTranslatef((*it)->location().x_, (*it)->location().y_ - 40.f, 0.f);
-            glScalef(0.7f, 0.7f, 0.f);
-            glRotatef(fmod(timer::totalTime()*(-180.f), 360.f), 0.f, 0.f, 1.f);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE);
+    for (std::list<Ship*>::const_iterator it = ships_.begin(); it != ships_.end(); ++it) {
 
-            // reverse
-            glColor3f(1.f, 0.7f, 0.9f);
-            glBegin(GL_QUADS);
-                    const int posX = 1;
-                    const int posY = 1;
-                    glTexCoord2f(posX*0.15625f,     posY*0.15625f);     glVertex2f(-35, -35);
-                    glTexCoord2f(posX*0.15625f,     (posY+1)*0.15625f); glVertex2f(-35, +35);
-                    glTexCoord2f((posX+1)*0.15625f, (posY+1)*0.15625f); glVertex2f(+35, +35);
-                    glTexCoord2f((posX+1)*0.15625f, posY*0.15625f);     glVertex2f(+35, -35);
-            glEnd();
+        glPushMatrix();
+        glLoadIdentity();
+        glTranslatef((*it)->location().x_, (*it)->location().y_ - 40.f, 0.f);
+        glScalef(0.7f, 0.7f, 0.f);
+        glRotatef(fmod(timer::totalTime()*(-180.f), 360.f), 0.f, 0.f, 1.f);
 
-            glPopMatrix();
-        }
+        // reverse
+        glColor3f(1.f, 0.7f, 0.9f);
+        glBegin(GL_QUADS);
+                const int posX = 1;
+                const int posY = 1;
+                glTexCoord2f(posX*0.15625f,     posY*0.15625f);     glVertex2f(-35, -35);
+                glTexCoord2f(posX*0.15625f,     (posY+1)*0.15625f); glVertex2f(-35, +35);
+                glTexCoord2f((posX+1)*0.15625f, (posY+1)*0.15625f); glVertex2f(+35, +35);
+                glTexCoord2f((posX+1)*0.15625f, posY*0.15625f);     glVertex2f(+35, -35);
+        glEnd();
+
+        glPopMatrix();
     }
 }
 


### PR DESCRIPTION
By adding the return statement on line 27, the code can avoid using an _else_ on line 29, and can unindent the block from lines 30 - 50
