### PR TITLE
Fixed serious compiler warning no-return-in-nonvoid-function

### DIFF
--- a/include/Specials/NoSpecial.hpp
+++ b/include/Specials/NoSpecial.hpp
@@ -32,7 +32,7 @@ class NoSpecial: public Special {
         /// Does nothing.
         void activate() const {}
 
-        float radius() const {}
+        float radius() const { return .0F; }
 
         /// Draws the special.
         void draw(float alpha) const;

--- a/include/Weapons/NoWeapon.hpp
+++ b/include/Weapons/NoWeapon.hpp
@@ -35,13 +35,13 @@ class NoWeapon: public Weapon {
         void draw(float alpha) const {}
 
         /// Returns the maximum distance from which this weapon should be used.
-        float maxDistance() const {}
+        float maxDistance() const { return .0F; }
 
         /// Returns the minimum distance from which this weapon should be used.
-        float minDistance() const {}
+        float minDistance() const { return .0F; }
 
         /// Returns the maximum angle from which this weapon should be used.
-        float maxAngle()   const {}
+        float maxAngle() const { return .0F; }
 };
 
 # endif // NOWEAPON_HPP_INCLUDED

--- a/src/Interface/Tab.cpp
+++ b/src/Interface/Tab.cpp
@@ -110,6 +110,7 @@ bool Tab::tabNext() {
             return true;
         }
     }
+    return false;
 }
 
 bool Tab::tabPrevious() {
@@ -140,6 +141,7 @@ bool Tab::tabPrevious() {
             return true;
         }
     }
+    return false;
 }
 
 


### PR DESCRIPTION
or rather something the @openSUSE check scripts detect as serious. This is actually just to silence them. The code paths are probably unused.