### PR TITLE
Fixed out-of-order array bounds check.

### DIFF
--- a/src/Media/sound.cpp
+++ b/src/Media/sound.cpp
@@ -47,8 +47,8 @@ namespace sound {
             // check if sound is already loaded
             if (sounds_[sound] != NULL) {
                 // if its already loaded search for free soundChannel_
-                int i(0);
-                while (soundChannel_[i].getStatus() == sf::Sound::Playing && i<CHANNELCOUNT) ++i;
+                int i = 0;
+                while((i < CHANNELCOUNT) && (soundChannel_[i].getStatus() == sf::Sound::Playing)) i++;
                 if (i < CHANNELCOUNT) {
                     // play sound with random pitch
                     soundChannel_[i].setBuffer(*sounds_[sound]);


### PR DESCRIPTION
Bounds were being checked only after the out-of-bounds check, causing a segfault when all channels were in use.

Not much to this one but it caused some crashes when I tried to play this today... The fix is pretty straightforward.