### PR TITLE
Remove old Debian menu leftovers

### DIFF
--- a/resources/mars
+++ b/resources/mars
@@ -1,6 +1,0 @@
-?package(mars): needs="X11"\
-        section="Games/Action"\
-        title="M.A.R.S."\
-        command="mars"\
-        icon="/usr/share/pixmaps/mars.xpm"\
-        hints="2D,Shooter,Multiplayer,Mars,Space"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,12 +139,6 @@ if(UNIX)
 		DESTINATION
 			${CMAKE_INSTALL_FULL_MANDIR}/man6
 	)
-    #install(
-    #FILES
-    #${MARS_SOURCE_DIR}/resources/mars
-    #DESTINATION
-    #${CMAKE_INSTALL_PREFIX}/share/menu
-    #)
 else(UNIX)
 	# executable
 	install(


### PR DESCRIPTION
commit f5519b9dde55727296737db071cb7d01c58b7bfa stops installing the
Debian menu file, which has not been installed for the last 10 years.
Furthermore, the Debian menu was officially deprecated more than 6
years ago [1], so simply drop the old Debian menu file for good.

[1] https://lists.debian.org/debian-devel-announce/2015/09/msg00000.html