### PR TITLE
Fix various bugs

### DIFF
--- a/include/DecoObjects/DecoObject.hpp
+++ b/include/DecoObjects/DecoObject.hpp
@@ -24,6 +24,8 @@ this program.  If not, see <http://www.gnu.org/licenses/>. */
 
 class DecoObject {
     public:
+        virtual ~DecoObject() = default;
+
         /// Draws the DecoObject.
         virtual void draw() const = 0;
 };

--- a/include/Games/Game.hpp
+++ b/include/Games/Game.hpp
@@ -35,7 +35,7 @@ class Game {
         /// particles::clear(), spaceObjects::clear(),
         /// controllers::clear(), players::clear(), zones::clear(),
         /// decoObjects::clear(), items::clear().
-        ~Game();
+        virtual ~Game();
 
         /// Updates the game.
         /// Has to be called every frame.

--- a/include/Hud/HudElement.hpp
+++ b/include/Hud/HudElement.hpp
@@ -20,6 +20,7 @@ this program.  If not, see <http://www.gnu.org/licenses/>. */
 
 class HudElement {
     public:
+        virtual ~HudElement() = default;
         virtual void draw() const = 0;
         virtual void update() {};
 };

--- a/include/Interface/UiElement.hpp
+++ b/include/Interface/UiElement.hpp
@@ -27,6 +27,7 @@ this program.  If not, see <http://www.gnu.org/licenses/>. */
 class UiElement {
     public:
         UiElement(Vector2f const& topLeft, int width, int height);
+        virtual ~UiElement() = default;
 
         virtual void mouseMoved(Vector2f const& position);
         virtual void mouseWheelMoved(Vector2f const& position, int delta) {}

--- a/include/Items/PowerUp.hpp
+++ b/include/Items/PowerUp.hpp
@@ -31,7 +31,7 @@ class PowerUp {
         PowerUp(items::PowerUpType type, Vector2f const& location, float radius,
                 float totalLifeTime, int texX, int texY, Color3f const& bgColor);
 
-        ~PowerUp();
+        virtual ~PowerUp();
 
         virtual void update();
         virtual void draw() const;

--- a/include/Players/Player.hpp
+++ b/include/Players/Player.hpp
@@ -27,6 +27,7 @@ class Team;
 class Player {
     public:
         Player(controllers::ControlType controlType);
+        virtual ~Player() = default;
 
         void                      resetPoints();
 

--- a/include/SpaceObjects/SpaceObject.hpp
+++ b/include/SpaceObjects/SpaceObject.hpp
@@ -33,6 +33,7 @@ class SpaceObject {
                     mass_(mass),
                     damageSource_(NULL),
                     type_(type) {}
+        virtual ~SpaceObject() = default;
 
         virtual void update() = 0;
         virtual void draw() const = 0;

--- a/include/Specials/Special.hpp
+++ b/include/Specials/Special.hpp
@@ -30,6 +30,7 @@ class Special {
     public:
         /// Ctor which constructs the base special.
         Special(specials::SpecialType type, Ship* parent, sf::String name);
+        virtual ~Special() = default;
 
         /// This function is called whenever the special is activated.
         virtual void activate() const = 0;

--- a/include/Teams/Team.hpp
+++ b/include/Teams/Team.hpp
@@ -31,6 +31,7 @@ class KeyController;
 class Team {
     public:
         Team(Color3f const& color);
+        virtual ~Team() = default;
 
         void update();
 

--- a/include/TrailEffects/Trail.hpp
+++ b/include/TrailEffects/Trail.hpp
@@ -23,6 +23,7 @@ class SpaceObject;
 class Trail {
     public:
         Trail(SpaceObject* target);
+        virtual ~Trail() = default;
 
         virtual void update() = 0;
         virtual void draw() const = 0;

--- a/include/Weapons/Weapon.hpp
+++ b/include/Weapons/Weapon.hpp
@@ -30,6 +30,7 @@ class Weapon {
     public:
         /// Ctor which constructs the base Weapon.
         Weapon(weapons::WeaponType type, Ship* parent, sf::String name);
+        virtual ~Weapon() = default;
 
         /// This function is called whenever the weapon is fired.
         virtual void fire() const = 0;

--- a/include/Zones/Zone.hpp
+++ b/include/Zones/Zone.hpp
@@ -26,6 +26,8 @@ class SpaceObject;
 
 class Zone {
     public:
+        virtual ~Zone() = default;
+
         /// Returns true, if the given SpaceObject is inside this Zone.
         virtual bool isInside(SpaceObject const& toBeChecked) const = 0;
 

--- a/src/Games/Game.cpp
+++ b/src/Games/Game.cpp
@@ -32,7 +32,6 @@ this program.  If not, see <http://www.gnu.org/licenses/>. */
 # include "Menu/menus.hpp"
 # include "System/window.hpp"
 # include "Media/announcer.hpp"
-# include "Shaders/postFX.hpp"
 # include "SpaceObjects/stars.hpp"
 # include "TrailEffects/trailEffects.hpp"
 # include "Teams/teams.hpp"
@@ -76,7 +75,6 @@ void Game::update() {
         spaceObjects::update();
         particles::update();
         items::update();
-        postFX::update();
         trailEffects::update();
 
         if (teams::getFirstPoints() >= pointLimit_) {

--- a/src/Games/games.cpp
+++ b/src/Games/games.cpp
@@ -31,6 +31,7 @@ this program.  If not, see <http://www.gnu.org/licenses/>. */
 # include "Media/music.hpp"
 # include "Menu/menus.hpp"
 # include "Hud/hud.hpp"
+# include "Shaders/postFX.hpp"
 # include "System/window.hpp"
 
 # include <SFML/OpenGL.hpp>
@@ -84,6 +85,8 @@ namespace games {
     }
 
     void draw() {
+        postFX::update();
+
         window::startDrawSpace();
 
         currentGame_->draw();

--- a/src/Shaders/postFX.cpp
+++ b/src/Shaders/postFX.cpp
@@ -42,6 +42,13 @@ namespace postFX {
             bumpMap_.setActive(true);
             bumpMap_.clear(sf::Color(127, 0, 127));
 
+            glViewport(0, 0, SPACE_X_RESOLUTION / 2, SPACE_Y_RESOLUTION / 2);
+            glMatrixMode(GL_PROJECTION);
+            glLoadIdentity();
+            glOrtho(0.f, SPACE_X_RESOLUTION, SPACE_Y_RESOLUTION, 0.f, -1, 1);
+            glMatrixMode(GL_MODELVIEW);
+            glLoadIdentity();
+
             particles::drawHeat();
             decoObjects::drawHeat();
 
@@ -77,10 +84,6 @@ namespace postFX {
         if (supported()) {
             postFX_.loadFromFile(settings::C_dataPath + "shaders/bump.frag", sf::Shader::Fragment);
             bumpMap_.create(SPACE_X_RESOLUTION*0.5f, SPACE_Y_RESOLUTION*0.5f);
-            glViewport(0,0,SPACE_X_RESOLUTION*0.5f,SPACE_Y_RESOLUTION*0.5f);
-            glOrtho(0, SPACE_X_RESOLUTION, SPACE_Y_RESOLUTION, 0, -1, 1);
-            glEnable(GL_BLEND);
-            glMatrixMode(GL_MODELVIEW);
             postFX_.setParameter("BumpMap", bumpMap_.getTexture());
             postFX_.setParameter("Exposure", exposure_);
         }

--- a/src/System/window.cpp
+++ b/src/System/window.cpp
@@ -51,7 +51,6 @@ namespace window {
 
         Vector2f         viewPort_;
         float            scale_(static_cast<float>(settings::C_resX)/SPACE_X_RESOLUTION);
-        int              clearCount_(0);
         float            joyButtonTimer_(0.f);
         const float      ratio(static_cast<float>(SPACE_X_RESOLUTION)/static_cast<float>(SPACE_Y_RESOLUTION));
 
@@ -86,7 +85,6 @@ namespace window {
                 viewPort_.y_ = windowWidth / ratio;
                 viewPort_.x_  = windowWidth;
             }
-            glClear(GL_COLOR_BUFFER_BIT);
 
             setViewPort();
 
@@ -160,10 +158,6 @@ namespace window {
 
         void display() {
             window_.display();
-            if (++clearCount_ > 30) {
-                glClear(GL_COLOR_BUFFER_BIT);
-                clearCount_ = 0;
-            }
         }
     }
 
@@ -214,9 +208,6 @@ namespace window {
 
         resized();
 
-        // setup OpenGL rendering context, bg color
-        glClearColor(0.f, 0.f, 0.f, 0.f);
-
         // Edit the OpenGL projection matrix
         glMatrixMode(GL_PROJECTION);
         glLoadIdentity();
@@ -243,6 +234,10 @@ namespace window {
     }
 
     void startDrawSpace() {
+        window_.setActive(true);
+        glClearColor(0.f, 0.f, 0.f, 1.f);
+        glClear(GL_COLOR_BUFFER_BIT);
+
         if (settings::C_shaders)
             backBuffer_.setActive(true);
 

--- a/src/System/window.cpp
+++ b/src/System/window.cpp
@@ -92,7 +92,6 @@ namespace window {
                 backBuffer_.setActive(true);
                 backBuffer_.clear();
                 backBuffer_.create(viewPort_.x_, viewPort_.y_);
-                glViewport(0,0,viewPort_.x_, viewPort_.y_);
                 backBuffer_.setSmooth(false);
             }
         }
@@ -238,8 +237,10 @@ namespace window {
         glClearColor(0.f, 0.f, 0.f, 1.f);
         glClear(GL_COLOR_BUFFER_BIT);
 
-        if (settings::C_shaders)
+        if (settings::C_shaders) {
             backBuffer_.setActive(true);
+            glViewport(0,0,viewPort_.x_, viewPort_.y_);
+        }
 
         glMatrixMode(GL_PROJECTION);
         glLoadIdentity();

--- a/src/Teams/CKTeam.cpp
+++ b/src/Teams/CKTeam.cpp
@@ -68,6 +68,7 @@ void CKTeam::checkPowerUps() {
 
     powerUpLocations_.clear();
     std::list<PowerUp*> const& powerUps = items::getPowerUps();
+    powerUpLocations_.reserve(powerUps.size());
     for (std::list<PowerUp*>::const_iterator it=powerUps.begin(); it!=powerUps.end(); ++it) {
         if (!(*it)->isCollected()) {
             powerUpLocations_.push_back((*it)->location());

--- a/src/Teams/DMTeam.cpp
+++ b/src/Teams/DMTeam.cpp
@@ -67,6 +67,7 @@ void DMTeam::checkPowerUps() {
 
     powerUpLocations_.clear();
     std::list<PowerUp*> const& powerUps = items::getPowerUps();
+    powerUpLocations_.reserve(powerUps.size());
     for (std::list<PowerUp*>::const_iterator it=powerUps.begin(); it!=powerUps.end(); ++it) {
         if (!(*it)->isCollected()) {
             powerUpLocations_.push_back((*it)->location());

--- a/src/Teams/SBTeam.cpp
+++ b/src/Teams/SBTeam.cpp
@@ -65,6 +65,7 @@ void SBTeam::checkPowerUps() {
 
     powerUpLocations_.clear();
     std::list<PowerUp*> const& powerUps = items::getPowerUps();
+    powerUpLocations_.reserve(powerUps.size());
     for (std::list<PowerUp*>::const_iterator it=powerUps.begin(); it!=powerUps.end(); ++it) {
         if (!(*it)->isCollected()) {
             powerUpLocations_.push_back((*it)->location());

--- a/src/Teams/TDMTeam.cpp
+++ b/src/Teams/TDMTeam.cpp
@@ -66,6 +66,7 @@ void TDMTeam::checkPowerUps() {
 
     powerUpLocations_.clear();
     std::list<PowerUp*> const& powerUps = items::getPowerUps();
+    powerUpLocations_.reserve(powerUps.size());
     for (std::list<PowerUp*>::const_iterator it=powerUps.begin(); it!=powerUps.end(); ++it) {
         if (!(*it)->isCollected()) {
             powerUpLocations_.push_back((*it)->location());

--- a/src/Teams/TutTeam.cpp
+++ b/src/Teams/TutTeam.cpp
@@ -67,6 +67,7 @@ void TutTeam::checkPowerUps() {
 
     powerUpLocations_.clear();
     std::list<PowerUp*> const& powerUps = items::getPowerUps();
+    powerUpLocations_.reserve(powerUps.size());
     for (std::list<PowerUp*>::const_iterator it=powerUps.begin(); it!=powerUps.end(); ++it) {
         if (!(*it)->isCollected()) {
             powerUpLocations_.push_back((*it)->location());


### PR DESCRIPTION
Fixes for various bugs I found while porting this to SFML 3. These apply to SFML 2 as well.

* A few bugs found by ASan (virtual destructors and a use-after-free)
* A bunch of issues related to shaders:
  * Clear the window on every frame. On my PC if I enable shaders I get visual glitches and flickering if I don't do this.
  * Run the postFX shader on every frame. This fixes some visual issues where we display a few frames with the wrong bump map.
  * Adjust the way the viewports are set when shaders are used. The current code sets the viewports once on startup which doesn't work.